### PR TITLE
bugfix: fixed rootcert from argument

### DIFF
--- a/csv_recorder/csv_recorder.py
+++ b/csv_recorder/csv_recorder.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     base_url = f"https://{args.host}/api/v1"
     info_endpoint = base_url + "/info"
     process_endpoint = base_url + "/process"
-    rootcert = "root_cert.crt"
+    rootcert = args.cert
 
     # configure http client session
     session = requests.Session()


### PR DESCRIPTION
In csv_recorder.py the argument for setting the certificate file was not used and was always set to "root_cert.crt".

With this PR, the certificate file can be set by giving it as an argument.